### PR TITLE
refactor: Player & enemy movements

### DIFF
--- a/include/player.h
+++ b/include/player.h
@@ -18,6 +18,7 @@ class Player {
   Vector2D getPosition() const { return position; }
   int getHealth() const { return health; }
   int getMaxHealth() const { return maxHealth; }
+  bool isAlive() const { return health > 0; }
 
   // Combat
   void takeDamage(int damage);

--- a/src/enemy.cpp
+++ b/src/enemy.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdlib>
 
 Enemy::Enemy(int x, int y, char symbol)
     : position(x, y), symbol(symbol), health(30), attackDamage(5) {}
@@ -9,16 +10,33 @@ Enemy::Enemy(int x, int y, char symbol)
 void Enemy::moveTo(Vector2D newPos) { position = newPos; }
 
 void Enemy::moveTowardPlayer(Vector2D playerPos) {
-  // Simple AI: move one step toward player
-  if (position.x < playerPos.x)
-    position.x++;
-  else if (position.x > playerPos.x)
-    position.x--;
+  // 25% chance to to not move.
+  bool noMove = (std::rand() % 4) == 3;
 
-  if (position.y < playerPos.y)
-    position.y++;
-  else if (position.y > playerPos.y)
-    position.y--;
+  // make move toward player random in direction choice.
+  int dir = std::rand() % 2;
+
+  if (!noMove) {
+    switch (dir) {
+      // vertical dir.
+      case 0:
+        if (position.y < playerPos.y) {
+          position.y++;
+        } else if (position.y > playerPos.y) {
+          position.y--;
+        }
+        break;
+
+      // horizontal dir.
+      case 1:
+        if (position.x < playerPos.x) {
+          position.x++;
+        } else if (position.x > playerPos.x) {
+          position.x--;
+        }
+        break;
+    }
+  }
 }
 
 void Enemy::takeDamage(int damage) { health -= damage; }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -105,7 +105,10 @@ void Game::handleInput() {
       break;
   }
 
-  player.moveTo(newPos);
+  // only allow movement if player alive.
+  if (player.isAlive()) {
+    player.moveTo(newPos);
+  }
 }
 
 /**

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -35,10 +35,12 @@ Game::Game(int width, int height)
  */
 void Game::run() {
   printw("Roguelike Game Started! Use arrow keys to move. Press Q to quit.\n");
-  printw("Press any key to begin...\n");
+  printw("Press SPACE to begin...\n");
 
-  box(stdscr, 0, 0);
-  refresh();
+  int ch;
+  do {
+    ch = getch();
+  } while (ch != ' ');
 
   // Set frame rate control variables
   const int FPS = 20;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -41,7 +41,7 @@ void Game::run() {
   refresh();
 
   // Set frame rate control variables
-  const int FPS = 60;
+  const int FPS = 30;
   const int FRAME_TIME = 1000 / FPS;
 
   while (isRunning) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -138,9 +138,11 @@ void Game::render() {
   clear();
   box(stdscr, 0, 0);
 
-  // Draw player
-  Vector2D playerPos = player.getPosition();
-  mvaddch(playerPos.y, playerPos.x, '@');
+  // Draw player... if alive.
+  if (player.isAlive()) {
+    Vector2D playerPos = player.getPosition();
+    mvaddch(playerPos.y, playerPos.x, '@');
+  }
 
   // Draw enemies
   for (const auto& enemy : enemies) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -41,7 +41,7 @@ void Game::run() {
   refresh();
 
   // Set frame rate control variables
-  const int FPS = 30;
+  const int FPS = 20;
   const int FRAME_TIME = 1000 / FPS;
 
   while (isRunning && player.isAlive()) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -44,7 +44,7 @@ void Game::run() {
   const int FPS = 30;
   const int FRAME_TIME = 1000 / FPS;
 
-  while (isRunning) {
+  while (isRunning && player.isAlive()) {
     // -------- Frame start --------
     auto start = std::chrono::high_resolution_clock::now();
     handleInput();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,13 +9,17 @@ int main() {
   cbreak();
   noecho();
   nodelay(stdscr, TRUE);
+
   // include multiple special keys including keypad
   keypad(stdscr, TRUE);
+
   // Remove cursor from screen
   curs_set(0);
+
   // get terminal size
   getmaxyx(stdscr, maxY, maxX);
   Game game(maxX, maxY);
   game.run();
+
   return 0;
 }


### PR DESCRIPTION
Player & enemy movement speed is completely governed by the FPS -- lowered this to 20. Overall, not much one can do in terms of movement. The terminal is a grid of rows & columns, meaning there is no fractional movements.

Changed enemy movement to be only one directional per frame & added a 25% chance of no movement for a given frame.

Fixed a few things as well:
- Player still rendered after death.
- Movement still available after death.
- Game loop still going after player death.
- Game starts before "any key" -- changed this to spacebar. See specific commit for details.

Would rec a rebase merge here... god help us.