### PR TITLE
feat: Adding GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,37 @@
+name: Bug
+description: Report a bug or unintended behavior
+title: "fix: <description>"
+labels:
+  - fix
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: What is happening?
+      placeholder: Describe the bug clearly
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to Reproduce
+      placeholder: |
+        1. Start game
+        2. Open menu
+        3. Enemy freezes
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      placeholder: What should happen instead?
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Logs, screenshots, theories, related systems, etc.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,28 @@
+name: Feature
+description: Propose a new feature or gameplay/system improvement
+title: "feat: <description>"
+labels:
+  - feat
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What are we adding?
+      placeholder: Add a short description of the feature
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Why does this feature matter?
+      placeholder: Explain the gameplay, technical, or UX reason
+
+  - type: textarea
+    id: implementation
+    attributes:
+      label: Possible Implementation
+      description: Optional notes on how this could work
+      placeholder: Systems, algorithms, files, ideas, etc.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## Summary
+
+Describe the change briefly.
+
+---
+
+## Related Issues
+
+Closes #
+
+---
+
+## Changes Made
+
+- 
+- 
+- 
+
+---
+
+## Notes
+
+Anything reviewers should know.


### PR DESCRIPTION
Made simple GitHub issue (feature & bug) templates & a PR template. Should speed up issue creation and PR reviews... hopefully. If not, shit is fluid, we can remove.

Also, just to note: these should auto-fill when making an issue or PR. We don't copy and paste these. See: <https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests>