### PR TITLE
feat: Adding speed to entities

### DIFF
--- a/include/enemy.h
+++ b/include/enemy.h
@@ -13,11 +13,13 @@ class Enemy : public Entity {
    * @param y Starting row position of enemy.
    * @param symbol Terminal representation of enemy. By default, 'E'.
    * @param health Starting health of enemy. By default, 100.
+   * @param speed Moves per second. For example, if speed = 60 → can move every
+   frame at 60fps. By default, 10.
    * @param attackDamage The attack damage of enemy. By default, 10.
    */
-  Enemy(int x, int y, char symbol = 'E', int health = 100,
+  Enemy(int x, int y, char symbol = 'E', int health = 100, int speed = 10,
         int attackDamage = 10)
-      : Entity(x, y, symbol, health), attackDamage(attackDamage) {};
+      : Entity(x, y, symbol, health, speed), attackDamage(attackDamage) {};
 
   /**
    * @brief Get the enemy's attack damage.

--- a/include/entity.h
+++ b/include/entity.h
@@ -64,7 +64,7 @@ class Entity {
   /**
    * @brief Get the speed as frequency.
    *
-   * @return constexpr std::chrono::nanoseconds
+   * @return std::chrono::nanoseconds
    */
   std::chrono::nanoseconds getSpeedHz() const {
     if (speed > 0) {

--- a/include/entity.h
+++ b/include/entity.h
@@ -66,7 +66,7 @@ class Entity {
    *
    * @return constexpr std::chrono::nanoseconds
    */
-  constexpr std::chrono::nanoseconds getSpeedHz() {
+  std::chrono::nanoseconds getSpeedHz() const {
     if (speed > 0) {
       return std::chrono::nanoseconds(1000000000 / speed);
     }

--- a/include/entity.h
+++ b/include/entity.h
@@ -1,12 +1,18 @@
 #ifndef ENTITY_H
 #define ENTITY_H
 
+#include <chrono>
+
 #include "vector2d.h"
 
 class Entity {
  public:
-  Entity(int x, int y, char symbol, int health)
-      : position(x, y), symbol(symbol), health(health) {};
+  Entity(int x, int y, char symbol, int health, int speed)
+      : position(x, y),
+        symbol(symbol),
+        health(health),
+        speed(speed),
+        lastMoveTime(std::chrono::high_resolution_clock::now()) {};
 
   virtual ~Entity() = default;
 
@@ -52,6 +58,39 @@ class Entity {
   Vector2D position;
   char symbol;
   int health;
+  int speed;
+  std::chrono::high_resolution_clock::time_point lastMoveTime;
+
+  /**
+   * @brief Get the speed as frequency.
+   *
+   * @return constexpr std::chrono::nanoseconds
+   */
+  constexpr std::chrono::nanoseconds getSpeedHz() {
+    if (speed > 0) {
+      return std::chrono::nanoseconds(1000000000 / speed);
+    }
+
+    return std::chrono::nanoseconds::max();
+  };
+
+  /**
+   * @brief Move hook that moves player to new position based on their speed.
+   *
+   * @param newPos The potential new position to move entitiy.
+   *
+   */
+  void moveHook(Vector2D newPos) {
+    auto hook_time = std::chrono::high_resolution_clock::now();
+    auto time_delta = hook_time - lastMoveTime;
+
+    // if time since last move is >= set speed, entity can move. otherwise,
+    // leave as current position.
+    if (time_delta >= getSpeedHz()) {
+      lastMoveTime = hook_time;
+      moveTo(newPos);
+    };
+  };
 };
 
 #endif

--- a/include/game.h
+++ b/include/game.h
@@ -1,6 +1,7 @@
 #ifndef GAME_H
 #define GAME_H
 
+#include <chrono>
 #include <memory>
 #include <vector>
 
@@ -17,14 +18,16 @@ class Game {
    *
    * @param width width of the game screen. By default, 175.
    * @param height height of the game screen. By default, 50.
+   * @param fps frames per second of game. By default, 60.
    *
    * Initializes the player in the center of the screen, generates the level,
    * and spawns enemies.
    *
    */
-  Game(int width = 175, int height = 50)
+  Game(int width = 175, int height = 50, int fps = 60)
       : screenWidth(width),
         screenHeight(height),
+        fps(fps),
         player(width / 2, height / 2),
         level(width, height),
         isRunning(true) {
@@ -40,12 +43,20 @@ class Game {
   void run();
 
  private:
-  int screenWidth, screenHeight;
+  const int screenWidth, screenHeight;
+  const int fps;
   Player player;
   Level level;
   std::vector<std::unique_ptr<Enemy>> enemies;
 
   bool isRunning;
+
+  /**
+   * @brief Get the frame duraction in milliseconds.
+   *
+   * @return std::chrono::milliseconds
+   */
+  auto getDuration() const { return std::chrono::milliseconds(1000 / fps); };
 
   /**
    * @brief Handles user input for player movement and game controls.

--- a/include/player.h
+++ b/include/player.h
@@ -12,9 +12,11 @@ class Player : public Entity {
    * @param x Starting column position of player.
    * @param y Starting row position of player.
    * @param health Starting health of player.
+   * @param speed Moves per second. For example, if speed = 60 → can move every
+   frame at 60fps. By default, 60.
    */
-  Player(int x, int y, int health = 100)
-      : Entity(x, y, '@', health), maxHealth(health) {};
+  Player(int x, int y, int health = 100, int speed = 60)
+      : Entity(x, y, '@', health, speed), maxHealth(health) {};
 
   /**
    * @brief Moves player up one row.

--- a/src/enemy.cpp
+++ b/src/enemy.cpp
@@ -4,34 +4,30 @@
 #include <cmath>
 #include <cstdlib>
 
+#include "vector2d.h"
+
 void Enemy::moveTowardPlayer(Vector2D playerPos) {
-  // 25% chance to to not move.
-  bool noMove = (std::rand() % 4) == 3;
+  bool needsX = position.x != playerPos.x;
+  bool needsY = position.y != playerPos.y;
 
-  // make move toward player random in direction choice.
-  int dir = std::rand() % 2;
+  int newX = position.x + (position.x < playerPos.x ? 1 : -1);
+  int newY = position.y + (position.y < playerPos.y ? 1 : -1);
 
-  if (!noMove) {
-    switch (dir) {
-      // vertical dir.
-      case 0:
-        if (position.y < playerPos.y) {
-          position.y++;
-        } else if (position.y > playerPos.y) {
-          position.y--;
-        }
-        break;
-
-      // horizontal dir.
-      case 1:
-        if (position.x < playerPos.x) {
-          position.x++;
-        } else if (position.x > playerPos.x) {
-          position.x--;
-        }
-        break;
+  Vector2D newPos = position;
+  if (needsX && needsY) {
+    // only randomly choose when both movements can be made.
+    if (std::rand() % 2 == 0) {
+      newPos.y = newY;
+    } else {
+      newPos.x = newX;
     }
+  } else if (needsX) {
+    newPos.x = newX;
+  } else if (needsY) {
+    newPos.y = newY;
   }
+
+  moveHook(newPos);
 }
 
 void Enemy::takeDamage(int damage) { health -= damage; }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -18,9 +18,7 @@ void Game::run() {
     ch = getch();
   } while (ch != ' ');
 
-  // Set frame rate control variables
-  const int FPS = 20;
-  const int FRAME_TIME = 1000 / FPS;
+  const auto frame_duration = getDuration();
 
   while (isRunning && player.isAlive()) {
     // -------- Frame start --------
@@ -31,15 +29,15 @@ void Game::run() {
 
     // -------- Frame end --------
     auto end = std::chrono::high_resolution_clock::now();
-    auto elapsed =
-        std::chrono::duration_cast<std::chrono::milliseconds>(end - start)
-            .count();
+    auto elapsed = end - start;
 
     // TODO: Sleep to maintain consistent frame rate (there may be a better
     // solution)
-    if (elapsed < FRAME_TIME) {
-      std::this_thread::sleep_for(
-          std::chrono::milliseconds(FRAME_TIME - elapsed));
+    if (elapsed < frame_duration) {
+      auto sleep_time =
+          frame_duration -
+          std::chrono::duration_cast<std::chrono::milliseconds>(elapsed);
+      std::this_thread::sleep_for(sleep_time);
     }
   }
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1,14 +1,14 @@
 #include "player.h"
 
-#include "level.h"
+#include "vector2d.h"
 
-void Player::moveUp() { position.y--; }
+void Player::moveUp() { moveHook(Vector2D(position.x, position.y - 1)); }
 
-void Player::moveDown() { position.y++; }
+void Player::moveDown() { moveHook(Vector2D(position.x, position.y + 1)); }
 
-void Player::moveLeft() { position.x--; }
+void Player::moveLeft() { moveHook(Vector2D(position.x - 1, position.y)); }
 
-void Player::moveRight() { position.x++; }
+void Player::moveRight() { moveHook(Vector2D(position.x + 1, position.y)); }
 
 void Player::takeDamage(int damage) {
   health -= damage;


### PR DESCRIPTION
## Summary

Each entity now has a `speed` attribute that corresponds to moves/sec.

---

## Related Issues

Closes #22 

---

## Changes Made

- Created an `fps` attribute & `getDuration()` method to `Game` (replacing `FPS` & `FRAME_TIME` in `Game::run()`).
- Increased FPS to 60.
- Implementing `speed` attribute to `Entity`.
- Adding `Entity::moveHook()` accounts for an entity's speed before moving.
- Refactored/fixed `Enemy::moveTowardsPlayer()` to not randomly not moved (relying on speed), and fixing randomly drawing directions that the enemy doesn't need to move to (see commit 8b65d46).

---

## Notes

There were really only 2 implementations of speed **I** could think of:

1. Having a frame counter that is passed in each move method.
2. Counting nanoseconds between last moves.

I opted for the latter... obviously.

Squash merge?
