### PR TITLE
feat: Creating a field of view

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ set(SOURCES
     src/player.cpp
     src/enemy.cpp
     src/level.cpp
+    src/fov.cpp
 )
 
 # Create executable.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,10 +3,12 @@ project(Roguelike)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-# Find and configure ncurses
+
+# Find and configure ncurses.
+set(CURSES_NEED_NCURSES TRUE)
 find_package(Curses REQUIRED)
 
-# Source files
+# Source files.
 set(SOURCES
     src/main.cpp
     src/game.cpp
@@ -15,19 +17,19 @@ set(SOURCES
     src/level.cpp
 )
 
-# Header files
-set(HEADERS
-    include/game.h
-    include/player.h
-    include/enemy.h
-    include/level.h
-    include/vector2d.h
+# Create executable.
+add_executable(roguelike ${SOURCES})
+
+target_include_directories(roguelike PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${CURSES_INCLUDE_DIRS}
 )
 
-# Create executable
-add_executable(roguelike ${SOURCES} ${HEADERS})
-
-# Link ncurses and include directories for project headers and ncurses
-target_include_directories(roguelike PRIVATE ${CMAKE_SOURCE_DIR}/include)
-target_include_directories(roguelike PRIVATE ${CURSES_INCLUDE_DIRS})
+# Link ncurses.
 target_link_libraries(roguelike PRIVATE ${CURSES_LIBRARIES})
+
+# compiler warnings.
+target_compile_options(roguelike PRIVATE
+    $<$<CXX_COMPILER_ID:GNU,Clang>:-Wall -Wextra -Wpedantic>
+    $<$<CXX_COMPILER_ID:MSVC>:/W4>
+)

--- a/include/enemy.h
+++ b/include/enemy.h
@@ -2,6 +2,7 @@
 #define ENEMY_H
 
 #include "entity.h"
+#include "fov.h"
 #include "vector2d.h"
 
 class Enemy : public Entity {
@@ -16,10 +17,14 @@ class Enemy : public Entity {
    * @param speed Moves per second. For example, if speed = 60 → can move every
    frame at 60fps. By default, 10.
    * @param attackDamage The attack damage of enemy. By default, 10.
+   * @param attackFOV The FOV of the enemy. By default, an ellipse FOV w/
+   * rx = 12, ry = 4.
    */
   Enemy(int x, int y, char symbol = 'E', int health = 100, int speed = 10,
-        int attackDamage = 10)
-      : Entity(x, y, symbol, health, speed), attackDamage(attackDamage) {};
+        int attackDamage = 10, FOV attackFOV = ellipseFOV(12, 4))
+      : Entity(x, y, symbol, health, speed),
+        attackDamage(attackDamage),
+        attackFOV(attackFOV) {};
 
   /**
    * @brief Get the enemy's attack damage.
@@ -44,6 +49,7 @@ class Enemy : public Entity {
 
  private:
   int attackDamage;
+  FOV attackFOV;
 };
 
 #endif

--- a/include/enemy.h
+++ b/include/enemy.h
@@ -18,10 +18,10 @@ class Enemy : public Entity {
    frame at 60fps. By default, 10.
    * @param attackDamage The attack damage of enemy. By default, 10.
    * @param attackFOV The FOV of the enemy. By default, an ellipse FOV w/
-   * rx = 12, ry = 4.
+   * rx = 20, ry = 10.
    */
   Enemy(int x, int y, char symbol = 'E', int health = 100, int speed = 10,
-        int attackDamage = 10, FOV attackFOV = ellipseFOV(12, 4))
+        int attackDamage = 10, FOV attackFOV = ellipseFOV(20, 10))
       : Entity(x, y, symbol, health, speed),
         attackDamage(attackDamage),
         attackFOV(attackFOV) {};

--- a/include/fov.h
+++ b/include/fov.h
@@ -44,11 +44,12 @@ class FOV {
 /**
  * @brief Create a filled ellipse FOV, compensating for terminal aspect ratio.
  *
- * @param radius Radius in columns (horizontal).
- * @param aspectRatio Row height / column width ratio (default 0.5 for 2:1).
+ * @param rx Radius in columns (horizontal).
+ * @param ry Radius in rows (vertical). NOTE: row heights are roughly equiv. to
+ * 2-3 column widths.
  * @return FOV
  *
  */
-FOV ellipseFOV(int radius, float aspectRatio = 0.5f);
+FOV ellipseFOV(int rx, int ry);
 
 #endif

--- a/include/fov.h
+++ b/include/fov.h
@@ -1,23 +1,23 @@
 #ifndef FOV_H
 #define FOV_H
 
-#include <unordered_set>
+#include <set>
 #include <vector>
 
 #include "vector2d.h"
 
 class FOV {
  public:
-  std::vector<Vector2D> cells;
+  std::set<Vector2D> offsets;
 
   /**
    * @brief Construct a new FOV.
    *
-   * @param offsets Vector of offset positions (from origin) that defines the
+   * @param offsets Set of offset positions (from origin) that defines the
    * FOV.
    *
    */
-  FOV(std::vector<Vector2D> offsets) : cells(offsets) {};
+  FOV(std::set<Vector2D> offsets) : offsets(std::move(offsets)) {};
 
   /**
    * @brief Determine if a position is in an origin's FOV.
@@ -32,13 +32,13 @@ class FOV {
   bool in(Vector2D origin, Vector2D position) const;
 
   /**
-   * @brief Return all positions covered by FOV from origin.
+   * @brief Return all absolute positions covered by FOV from origin.
    *
    * @param origin The position of origin with this FOV.
    * @return std::vector<Vector2D>
    *
    */
-  std::vector<Vector2D> absoluteCells(Vector2D origin) const;
+  std::vector<Vector2D> absoluteFOV(Vector2D origin) const;
 };
 
 /**

--- a/include/fov.h
+++ b/include/fov.h
@@ -13,10 +13,11 @@ class FOV {
   /**
    * @brief Construct a new FOV.
    *
-   * @param cells Vector of positions that defines the FOV.
+   * @param offsets Vector of offset positions (from origin) that defines the
+   * FOV.
    *
    */
-  FOV(std::vector<Vector2D> cells) : cells(cells) {};
+  FOV(std::vector<Vector2D> offsets) : cells(offsets) {};
 
   /**
    * @brief Determine if a position is in an origin's FOV.

--- a/include/fov.h
+++ b/include/fov.h
@@ -1,0 +1,53 @@
+#ifndef FOV_H
+#define FOV_H
+
+#include <unordered_set>
+#include <vector>
+
+#include "vector2d.h"
+
+class FOV {
+ public:
+  std::vector<Vector2D> cells;
+
+  /**
+   * @brief Construct a new FOV.
+   *
+   * @param cells Vector of positions that defines the FOV.
+   *
+   */
+  FOV(std::vector<Vector2D> cells) : cells(cells) {};
+
+  /**
+   * @brief Determine if a position is in an origin's FOV.
+   *
+   * Checks whether (position - origin) is one of the stored offsets.
+   *
+   * @param origin The position of origin with this FOV.
+   * @param position The position of the target.
+   * @return bool True if position is in FOV (based on origin).
+   *
+   */
+  bool in(Vector2D origin, Vector2D position) const;
+
+  /**
+   * @brief Return all positions covered by FOV from origin.
+   *
+   * @param origin The position of origin with this FOV.
+   * @return std::vector<Vector2D>
+   *
+   */
+  std::vector<Vector2D> absoluteCells(Vector2D origin) const;
+};
+
+/**
+ * @brief Create a filled ellipse FOV, compensating for terminal aspect ratio.
+ *
+ * @param radius Radius in columns (horizontal).
+ * @param aspectRatio Row height / column width ratio (default 0.5 for 2:1).
+ * @return FOV
+ *
+ */
+FOV ellipseFOV(int radius, float aspectRatio = 0.5f);
+
+#endif

--- a/include/vector2d.h
+++ b/include/vector2d.h
@@ -17,6 +17,11 @@ struct Vector2D {
   bool operator==(const Vector2D& other) const {
     return x == other.x && y == other.y;
   }
+
+  bool operator<(const Vector2D& other) const {
+    if (y != other.y) return y < other.y;
+    return x < other.x;
+  }
 };
 
 #endif

--- a/src/enemy.cpp
+++ b/src/enemy.cpp
@@ -7,27 +7,30 @@
 #include "vector2d.h"
 
 void Enemy::moveTowardPlayer(Vector2D playerPos) {
-  bool needsX = position.x != playerPos.x;
-  bool needsY = position.y != playerPos.y;
+  // only move toward player if in FOV.
+  if (attackFOV.in(position, playerPos)) {
+    bool needsX = position.x != playerPos.x;
+    bool needsY = position.y != playerPos.y;
 
-  int newX = position.x + (position.x < playerPos.x ? 1 : -1);
-  int newY = position.y + (position.y < playerPos.y ? 1 : -1);
+    int newX = position.x + (position.x < playerPos.x ? 1 : -1);
+    int newY = position.y + (position.y < playerPos.y ? 1 : -1);
 
-  Vector2D newPos = position;
-  if (needsX && needsY) {
-    // only randomly choose when both movements can be made.
-    if (std::rand() % 2 == 0) {
-      newPos.y = newY;
-    } else {
+    Vector2D newPos = position;
+    if (needsX && needsY) {
+      // only randomly choose when both movements can be made.
+      if (std::rand() % 2 == 0) {
+        newPos.y = newY;
+      } else {
+        newPos.x = newX;
+      }
+    } else if (needsX) {
       newPos.x = newX;
+    } else if (needsY) {
+      newPos.y = newY;
     }
-  } else if (needsX) {
-    newPos.x = newX;
-  } else if (needsY) {
-    newPos.y = newY;
-  }
 
-  moveHook(newPos);
+    moveHook(newPos);
+  }
 }
 
 void Enemy::takeDamage(int damage) { health -= damage; }

--- a/src/fov.cpp
+++ b/src/fov.cpp
@@ -1,0 +1,46 @@
+
+#include "fov.h"
+
+#include <set>
+#include <vector>
+
+bool FOV::in(Vector2D origin, Vector2D position) const {
+  Vector2D offset = origin - position;
+  return offsets.count(offset) > 0;
+};
+
+std::vector<Vector2D> FOV::absoluteFOV(Vector2D origin) const {
+  // initialize a vector of positions w/ size of number of offsets.
+  std::vector<Vector2D> positions;
+  positions.reserve(offsets.size());
+
+  // iterate through & get the absolute position based on origin pos.
+  for (const Vector2D& offset : offsets) {
+    positions.push_back(origin + offset);
+  };
+
+  return positions;
+};
+
+FOV ellipseFOV(int rx, int ry) {
+  // need to get all offsets to create an FOV.
+  std::set<Vector2D> offsets;
+
+  // iterate through -y --> y.
+  for (int dy = -ry; dy <= ry; ++dy) {
+    // find max x via ellipse eq. (w/ origin 0):
+    //    1 = (dx / rx)^2 + (dy / ry)^2
+    //    dx = rx * sqrt(1 - (dy / ry)^2)
+    // could've used std::ceil here, but rounding down is fine w/ me.
+    float y_norm = dy / ry;
+    int dx_max = static_cast<int>(rx * std::sqrt(1.0f - y_norm * y_norm));
+
+    // iterate through -dx --> dx.
+    for (int dx = -dx_max; dx <= dx_max; ++dx) {
+      offsets.insert({dx, dy});
+    };
+  }
+
+  // cooked.
+  return FOV(offsets);
+}

--- a/src/fov.cpp
+++ b/src/fov.cpp
@@ -32,12 +32,12 @@ FOV ellipseFOV(int rx, int ry) {
     //    1 = (dx / rx)^2 + (dy / ry)^2
     //    dx = rx * sqrt(1 - (dy / ry)^2)
     // could've used std::ceil here, but rounding down is fine w/ me.
-    float y_norm = dy / ry;
+    float y_norm = static_cast<float>(dy) / static_cast<float>(ry);
     int dx_max = static_cast<int>(rx * std::sqrt(1.0f - y_norm * y_norm));
 
     // iterate through -dx --> dx.
     for (int dx = -dx_max; dx <= dx_max; ++dx) {
-      offsets.insert({dx, dy});
+      offsets.insert(Vector2D(dx, dy));
     };
   }
 


### PR DESCRIPTION
## Summary

Created a field of view (`FOV`) object that creates an ordered set of offset positions that can be used to determine if a given position is in the FOV.

---

## Related Issues

Closes #23 

---

## Changes Made

- Created an `FOV` class.
- Composed the `Enemy` object with an `FOV` (via an `attackFOV` attrb.).
- Added condition in `Enemy::moveTowardsPlayer()` to only move if player is in enemies FOV.

---

## Notes

As mentioned, since the terminal row height is about 2-3 times the length of the terminal column length, the default FOV is an "ellipse" -- visually it's more like a circle.

I dont know what type of merge here. I kinda rebased off of #28 so i didnt have to explicitly define the header files. i think a rebase merge will account for this?

NOTE: dependent on PR #27 
