### PR TITLE
refactor: Changing entity speed from time-based to frame-based

### DIFF
--- a/include/enemy.h
+++ b/include/enemy.h
@@ -14,8 +14,8 @@ class Enemy : public Entity {
    * @param y Starting row position of enemy.
    * @param symbol Terminal representation of enemy. By default, 'E'.
    * @param health Starting health of enemy. By default, 100.
-   * @param speed Moves per second. For example, if speed = 60 → can move every
-   frame at 60fps. By default, 10.
+   * @param speed Frames per move. For example, speed = 2, means an enemy can
+   * move per every 2 frames/renders. By default, equal to 10.
    * @param attackDamage The attack damage of enemy. By default, 10.
    * @param attackFOV The FOV of the enemy. By default, an ellipse FOV w/
    * rx = 20, ry = 10.

--- a/include/entity.h
+++ b/include/entity.h
@@ -80,19 +80,6 @@ class Entity {
   int frameCounter;
 
   /**
-   * @brief Get the speed as frequency.
-   *
-   * @return std::chrono::nanoseconds
-   */
-  std::chrono::nanoseconds getSpeedHz() const {
-    if (speed > 0) {
-      return std::chrono::nanoseconds(1000000000 / speed);
-    }
-
-    return std::chrono::nanoseconds::max();
-  };
-
-  /**
    * @brief Move hook that moves player to new position based on their speed.
    *
    * @param newPos The potential new position to move entitiy.

--- a/include/entity.h
+++ b/include/entity.h
@@ -1,8 +1,6 @@
 #ifndef ENTITY_H
 #define ENTITY_H
 
-#include <chrono>
-
 #include "coordinate.h"
 
 class Entity {

--- a/include/entity.h
+++ b/include/entity.h
@@ -8,11 +8,7 @@
 class Entity {
  public:
   Entity(int x, int y, char symbol, int health, int speed)
-      : position(x, y),
-        symbol(symbol),
-        health(health),
-        speed(speed),
-        lastMoveTime(std::chrono::high_resolution_clock::now()) {};
+      : position(x, y), symbol(symbol), health(health), speed(speed) {};
 
   virtual ~Entity() = default;
 
@@ -59,7 +55,7 @@ class Entity {
   char symbol;
   int health;
   int speed;
-  std::chrono::high_resolution_clock::time_point lastMoveTime;
+  int frameCounter;
 
   /**
    * @brief Get the speed as frequency.
@@ -81,13 +77,11 @@ class Entity {
    *
    */
   void moveHook(Coordinate newPos) {
-    auto hook_time = std::chrono::high_resolution_clock::now();
-    auto time_delta = hook_time - lastMoveTime;
+    // when move hook is called, we assume a frame.
+    frameCounter += 1;
 
-    // if time since last move is >= set speed, entity can move. otherwise,
-    // leave as current position.
-    if (time_delta >= getSpeedHz()) {
-      lastMoveTime = hook_time;
+    if (frameCounter % speed == 0) {
+      frameCounter = 0;  // reset counter.
       moveTo(newPos);
     };
   };

--- a/include/entity.h
+++ b/include/entity.h
@@ -47,6 +47,30 @@ class Entity {
    */
   void moveTo(Coordinate newPos) { position = newPos; };
 
+  /**
+   * @brief Moves entity up one row.
+   *
+   */
+  void moveUp() { moveHook(Coordinate(position.x, position.y - 1)); };
+
+  /**
+   * @brief Moves entity down one row.
+   *
+   */
+  void moveDown() { moveHook(Coordinate(position.x, position.y + 1)); };
+
+  /**
+   * @brief Moves entity right one column.
+   *
+   */
+  void moveLeft() { moveHook(Coordinate(position.x - 1, position.y)); };
+
+  /**
+   * @brief Moves entity left one column.
+   *
+   */
+  void moveRight() { moveHook(Coordinate(position.x + 1, position.y)); };
+
   // abstract methods.
   virtual void takeDamage(int damage) = 0;
 

--- a/include/entity.h
+++ b/include/entity.h
@@ -32,6 +32,13 @@ class Entity {
   Coordinate getPosition() const { return position; };
 
   /**
+   * @brief Get entity speed.
+   *
+   * @return const int [frames / move]
+   */
+  int getSpeed() const { return speed; };
+
+  /**
    * @brief Entity is alive.
    *
    * @return bool

--- a/include/player.h
+++ b/include/player.h
@@ -12,35 +12,11 @@ class Player : public Entity {
    * @param x Starting column position of player.
    * @param y Starting row position of player.
    * @param health Starting health of player.
-   * @param speed Moves per second. For example, if speed = 60 → can move every
-   frame at 60fps. By default, 60.
+   * @param speed Frames per move. For example, speed = 2, means a player can
+   * move per every 2 frames/renders. By default, equal to 1.
    */
-  Player(int x, int y, int health = 100, int speed = 60)
+  Player(int x, int y, int health = 100, int speed = 1)
       : Entity(x, y, '@', health, speed), maxHealth(health) {};
-
-  /**
-   * @brief Moves player up one row.
-   *
-   */
-  void moveUp();
-
-  /**
-   * @brief Moves player down one row.
-   *
-   */
-  void moveDown();
-
-  /**
-   * @brief Moves player right one column.
-   *
-   */
-  void moveLeft();
-
-  /**
-   * @brief Moves player left one column.
-   *
-   */
-  void moveRight();
 
   /**
    * @brief Get the initial max health of player.

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2,14 +2,6 @@
 
 #include "coordinate.h"
 
-void Player::moveUp() { moveHook(Coordinate(position.x, position.y - 1)); }
-
-void Player::moveDown() { moveHook(Coordinate(position.x, position.y + 1)); }
-
-void Player::moveLeft() { moveHook(Coordinate(position.x - 1, position.y)); }
-
-void Player::moveRight() { moveHook(Coordinate(position.x + 1, position.y)); }
-
 void Player::takeDamage(int damage) {
   health -= damage;
   if (health < 0) health = 0;


### PR DESCRIPTION
## Summary

Changing how `Entity` speed is implemented from time-based to frame-based.

---

## Related Issues

Closes #35 

---

## Changes Made

- Added `Entity::frameCounter` to count the number of frames since last move attempt (resets after a move can be made).
- Refactored `Entity::moveHook()` to conditionally move based on the `Entity::frameCounter`.
- Added common move methods to `Entity` (removing them from `Player`).

---

## Notes

Speed is now based on frames/move (e.g., speed = 1 means you can move each frame).