### PR TITLE
feat: ncurses window overlays

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ set(SOURCES
     src/fov.cpp
     src/tile.cpp
     src/layers/map_layer.cpp
+    src/layers/entity_layer.cpp
 )
 
 # Create executable.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ set(SOURCES
     src/level.cpp
     src/fov.cpp
     src/tile.cpp
+    src/layers/map_layer.cpp
 )
 
 # Create executable.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ set(SOURCES
     src/layers/entity_layer.cpp
     src/layers/hud_layer.cpp
     src/layers/debug_layer.cpp
+    src/renderer.cpp
 )
 
 # Create executable.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ set(SOURCES
     src/layers/map_layer.cpp
     src/layers/entity_layer.cpp
     src/layers/hud_layer.cpp
+    src/layers/debug_layer.cpp
 )
 
 # Create executable.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ set(SOURCES
     src/tile.cpp
     src/layers/map_layer.cpp
     src/layers/entity_layer.cpp
+    src/layers/hud_layer.cpp
 )
 
 # Create executable.

--- a/include/game.h
+++ b/include/game.h
@@ -6,8 +6,13 @@
 #include <vector>
 
 #include "enemy.h"
+#include "layers/debug_layer.h"
+#include "layers/entity_layer.h"
+#include "layers/hud_layer.h"
+#include "layers/map_layer.h"
 #include "level.h"
 #include "player.h"
+#include "renderer.h"
 
 class Enemy;
 
@@ -21,7 +26,7 @@ class Game {
    * @param fps frames per second of game. By default, 60.
    *
    * Initializes the player in the center of the screen, generates the level,
-   * and spawns enemies.
+   * spawns enemies, and builds the render layer stack.
    *
    */
   Game(int width = 175, int height = 50, int fps = 60)
@@ -31,7 +36,25 @@ class Game {
         player(width / 2, height / 2),
         level(1),
         isRunning(true) {
+    // generate enemy objects first..
     spawnEnemies();
+
+    // add window overlays.
+    // TODO: probably want to create an Enum for layer ordering.
+    renderer.addLayer(
+        1, std::make_unique<MapLayer>(screenHeight, screenWidth, level));
+    renderer.addLayer(2, std::make_unique<EntityLayer>(
+                             screenHeight, screenWidth, player, enemies));
+    renderer.addLayer(
+        3, std::make_unique<HUDLayer>(screenHeight, screenWidth, player));
+
+    // if not prod, add the debug window.
+    // TODO: create debug & prod builds. <-- `NDEBUG` (no debug) can be enabled
+    // via a build flag: `-DNDEBUG`.
+#ifndef NDEBUG
+    renderer.addLayer(4, std::make_unique<DebugLayer>(screenHeight, screenWidth,
+                                                      currentFps, player));
+#endif
   };
 
   /**
@@ -45,11 +68,13 @@ class Game {
  private:
   const int screenWidth, screenHeight;
   const int fps;
+  double currentFps;
   Player player;
   Level level;
   std::vector<std::unique_ptr<Enemy>> enemies;
 
   bool isRunning;
+  Renderer renderer;
 
   /**
    * @brief Get the frame duraction in milliseconds.

--- a/include/layers/debug_layer.h
+++ b/include/layers/debug_layer.h
@@ -1,7 +1,7 @@
 #ifndef DEBUG_LAYER_H
 #define DEBUG_LAYER_H
 
-#include "coordinate.h"
+#include "player.h"
 #include "render_stack.h"
 
 class DebugLayer : public RenderStack {
@@ -11,16 +11,11 @@ class DebugLayer : public RenderStack {
    *
    * @param h Height of the layer window (in rows).
    * @param w Width of the layer window (in columns).
-   * @param fps The frames-per-second of game.
-   * @param frameTimeMs The milliseconds between frames after rendering.
-   * @param playerPos The current position of the player.
+   * @param currentFps Current frames-per-second game is rendering at.
+   * @param player The player object.
    */
-  DebugLayer(int h, int w, const int& fps, int& frameTimeMs,
-             const Coordinate& playerPos)
-      : RenderStack(h, w),
-        fps(fps),
-        frameTimeMs(frameTimeMs),
-        playerPos(playerPos) {};
+  DebugLayer(int h, int w, const double& currentFps, const Player& player)
+      : RenderStack(h, w), currentFps(currentFps), player(player) {};
 
   /**
    * @brief Draw frame timing and player position at the bottom row.
@@ -29,9 +24,8 @@ class DebugLayer : public RenderStack {
   void doRender() override;
 
  private:
-  const int& fps;
-  int& frameTimeMs;
-  const Coordinate& playerPos;
+  const double& currentFps;
+  const Player& player;
 };
 
 #endif

--- a/include/layers/debug_layer.h
+++ b/include/layers/debug_layer.h
@@ -1,0 +1,37 @@
+#ifndef DEBUG_LAYER_H
+#define DEBUG_LAYER_H
+
+#include "coordinate.h"
+#include "render_stack.h"
+
+class DebugLayer : public RenderStack {
+ public:
+  /**
+   * @brief Construct a new Debug Layer.
+   *
+   * @param h Height of the layer window (in rows).
+   * @param w Width of the layer window (in columns).
+   * @param fps The frames-per-second of game.
+   * @param frameTimeMs The milliseconds between frames after rendering.
+   * @param playerPos The current position of the player.
+   */
+  DebugLayer::DebugLayer(int h, int w, int fps, double frameTimeMs,
+                         Coordinate playerPos)
+      : RenderStack(h, w),
+        fps(fps),
+        frameTimeMs(frameTimeMs),
+        playerPos(playerPos) {};
+
+  /**
+   * @brief Draw frame timing and player position at the bottom row.
+   *
+   */
+  void doRender() override;
+
+ private:
+  int fps;
+  double frameTimeMs;
+  Coordinate playerPos;
+};
+
+#endif

--- a/include/layers/debug_layer.h
+++ b/include/layers/debug_layer.h
@@ -16,7 +16,7 @@ class DebugLayer : public RenderStack {
    * @param playerPos The current position of the player.
    */
   DebugLayer(int h, int w, const int& fps, double& frameTimeMs,
-             Coordinate& playerPos)
+             const Coordinate& playerPos)
       : RenderStack(h, w),
         fps(fps),
         frameTimeMs(frameTimeMs),
@@ -31,7 +31,7 @@ class DebugLayer : public RenderStack {
  private:
   const int& fps;
   double& frameTimeMs;
-  Coordinate& playerPos;
+  const Coordinate& playerPos;
 };
 
 #endif

--- a/include/layers/debug_layer.h
+++ b/include/layers/debug_layer.h
@@ -15,8 +15,8 @@ class DebugLayer : public RenderStack {
    * @param frameTimeMs The milliseconds between frames after rendering.
    * @param playerPos The current position of the player.
    */
-  DebugLayer::DebugLayer(int h, int w, int fps, double frameTimeMs,
-                         Coordinate playerPos)
+  DebugLayer(int h, int w, const int& fps, double& frameTimeMs,
+             Coordinate& playerPos)
       : RenderStack(h, w),
         fps(fps),
         frameTimeMs(frameTimeMs),
@@ -29,9 +29,9 @@ class DebugLayer : public RenderStack {
   void doRender() override;
 
  private:
-  int fps;
-  double frameTimeMs;
-  Coordinate playerPos;
+  const int& fps;
+  double& frameTimeMs;
+  Coordinate& playerPos;
 };
 
 #endif

--- a/include/layers/debug_layer.h
+++ b/include/layers/debug_layer.h
@@ -15,7 +15,7 @@ class DebugLayer : public RenderStack {
    * @param frameTimeMs The milliseconds between frames after rendering.
    * @param playerPos The current position of the player.
    */
-  DebugLayer(int h, int w, const int& fps, double& frameTimeMs,
+  DebugLayer(int h, int w, const int& fps, int& frameTimeMs,
              const Coordinate& playerPos)
       : RenderStack(h, w),
         fps(fps),
@@ -30,7 +30,7 @@ class DebugLayer : public RenderStack {
 
  private:
   const int& fps;
-  double& frameTimeMs;
+  int& frameTimeMs;
   const Coordinate& playerPos;
 };
 

--- a/include/layers/entity_layer.h
+++ b/include/layers/entity_layer.h
@@ -1,6 +1,7 @@
 #ifndef ENTITY_LAYER_H
 #define ENTITY_LAYER_H
 
+#include <memory>
 #include <vector>
 
 #include "enemy.h"

--- a/include/layers/entity_layer.h
+++ b/include/layers/entity_layer.h
@@ -22,8 +22,8 @@ class EntityLayer : public RenderStack {
    * @param player The player entity to draw each frame.
    * @param enemies The enemy list to draw each frame.
    */
-  EntityLayer::EntityLayer(int h, int w, const Player& player,
-                           const std::vector<std::unique_ptr<Enemy>>& enemies)
+  EntityLayer(int h, int w, const Player& player,
+              const std::vector<std::unique_ptr<Enemy>>& enemies)
       : RenderStack(h, w), player(player), enemies(enemies) {};
 
   /**

--- a/include/layers/entity_layer.h
+++ b/include/layers/entity_layer.h
@@ -1,0 +1,51 @@
+#ifndef ENTITY_LAYER_H
+#define ENTITY_LAYER_H
+
+#include <vector>
+
+#include "enemy.h"
+#include "player.h"
+#include "render_stack.h"
+
+class EntityLayer : public RenderStack {
+ public:
+  /**
+   * @brief Construct a new Entity Layer.
+   *
+   * NOTE: The reason we want to pass the player & enemies seperately is because
+   * we want to render the player last. Such that if a player attacks an enemy
+   * via melee, the player will render on top of the enemy.
+   *
+   * @param h Height of the layer window (in rows).
+   * @param w Width of the layer window (in columns).
+   * @param player The player entity to draw each frame.
+   * @param enemies The enemy list to draw each frame.
+   */
+  EntityLayer::EntityLayer(int h, int w, const Player& player,
+                           const std::vector<std::unique_ptr<Enemy>>& enemies)
+      : RenderStack(h, w), player(player), enemies(enemies) {};
+
+  /**
+   * @brief Draw enemy entities.
+   *
+   */
+  void drawEnemies();
+
+  /**
+   * @brief Draw player entity.
+   *
+   */
+  void drawPlayer();
+
+  /**
+   * @brief Draw all alive entities into the layer window.
+   *
+   */
+  void doRender() override;
+
+ private:
+  const Player& player;
+  const std::vector<std::unique_ptr<Enemy>>& enemies;
+};
+
+#endif

--- a/include/layers/hud_layer.h
+++ b/include/layers/hud_layer.h
@@ -1,0 +1,43 @@
+#ifndef HUD_LAYER_H
+#define HUD_LAYER_H
+
+#include "player.h"
+#include "render_stack.h"
+
+class HUDLayer : public RenderStack {
+ public:
+  /**
+   * @brief Construct a new HUD Layer.
+   *
+   * @param h Height of the layer window (in rows).
+   * @param w Width of the layer window in columns.
+   * @param player The player object to track stats, health, position, etc.
+   */
+  HUDLayer::HUDLayer(int h, int w, const Player& player)
+      : RenderStack(h, w), player(player) {};
+
+  /**
+   * @brief Draw player health bar.
+   *
+   * Defaults to being drawn directly above player position.
+   *
+   * @param offsetX The offset x (column) position (relative to player) to draw
+   * health bar. Positive offsets shift bar left, negative offsets shift bar
+   * right. By default, 0.
+   * @param offsetY The offset y (row) position (relative to player) to draw
+   * health bar. Positive offsets shift bar up, negative offsets shift bar
+   * down. By default, 1.
+   */
+  void drawPlayerHealthBar(int offsetX = 0, int offsetY = 1) {};
+
+  /**
+   * @brief Draw the HP indicator one row above the player's current position.
+   *
+   */
+  void doRender() override;
+
+ private:
+  const Player& player;
+};
+
+#endif

--- a/include/layers/hud_layer.h
+++ b/include/layers/hud_layer.h
@@ -13,7 +13,7 @@ class HUDLayer : public RenderStack {
    * @param w Width of the layer window in columns.
    * @param player The player object to track stats, health, position, etc.
    */
-  HUDLayer::HUDLayer(int h, int w, const Player& player)
+  HUDLayer(int h, int w, const Player& player)
       : RenderStack(h, w), player(player) {};
 
   /**

--- a/include/layers/hud_layer.h
+++ b/include/layers/hud_layer.h
@@ -28,7 +28,7 @@ class HUDLayer : public RenderStack {
    * health bar. Positive offsets shift bar up, negative offsets shift bar
    * down. By default, 1.
    */
-  void drawPlayerHealthBar(int offsetX = 0, int offsetY = 1) {};
+  void drawPlayerHealthBar(int offsetX = 0, int offsetY = 1);
 
   /**
    * @brief Draw the HP indicator one row above the player's current position.

--- a/include/layers/map_layer.h
+++ b/include/layers/map_layer.h
@@ -13,7 +13,7 @@ class MapLayer : public RenderStack {
    * @param w Width of the layer window (in columns).
    * @param level The level class whose current room will be drawn each frame.
    */
-  MapLayer::MapLayer(int h, int w, const Level& level)
+  MapLayer(int h, int w, const Level& level)
       : RenderStack(h, w), level(level) {};
 
   /**

--- a/include/layers/map_layer.h
+++ b/include/layers/map_layer.h
@@ -1,0 +1,35 @@
+#ifndef MAP_LAYER_H
+#define MAP_LAYER_H
+
+#include "level.h"
+#include "render_stack.h"
+
+class MapLayer : public RenderStack {
+ public:
+  /**
+   * @brief Construct a new Map Layer.
+   *
+   * @param h Height of the layer window (in rows).
+   * @param w Width of the layer window (in columns).
+   * @param level The level class whose current room will be drawn each frame.
+   */
+  MapLayer::MapLayer(int h, int w, const Level& level)
+      : RenderStack(h, w), level(level) {};
+
+  /**
+   * @brief Draw all room tiles into the map layer window.
+   *
+   */
+  void drawMap();
+
+  /**
+   * @brief Render map layer window.
+   *
+   */
+  void doRender() override;
+
+ private:
+  const Level& level;
+};
+
+#endif

--- a/include/render_stack.h
+++ b/include/render_stack.h
@@ -11,8 +11,7 @@ class RenderStack {
    * @param h Height of the layer window (in rows).
    * @param w Width of the layer window (in columns).
    */
-  RenderStack::RenderStack(int h, int w)
-      : win(newwin(h, w, 0, 0)), height(h), width(w) {};
+  RenderStack(int h, int w) : win(newwin(h, w, 0, 0)), height(h), width(w) {};
 
   // need to make sure the ncurses::WINDOW is deleted if object is.
   virtual ~RenderStack() {

--- a/include/render_stack.h
+++ b/include/render_stack.h
@@ -2,33 +2,72 @@
 #define RENDER_STACK_H
 
 #include <ncurses.h>
-#include <panel.h>
-
-#include <vector>
 
 class RenderStack {
  public:
   /**
    * @brief Construct a new Render Stack object.
    *
-   * @param panels Panel objects to render groupwise.
+   * @param h Height of the layer window (in rows).
+   * @param w Width of the layer window (in columns).
    */
-  RenderStack(std::vector<PANEL*> panels) : panels(panels) {};
+  RenderStack::RenderStack(int h, int w)
+      : win(newwin(h, w, 0, 0)), height(h), width(w) {};
+
+  // need to make sure the ncurses::WINDOW is deleted if object is.
+  virtual ~RenderStack() {
+    if (win) delwin(win);
+  };
+
+  // doing this to enforce no copies. each RenderStack object should be unique.
+  RenderStack(const RenderStack&) = delete;
+  RenderStack& operator=(const RenderStack&) = delete;
+  RenderStack(RenderStack&&) = delete;
+  RenderStack& operator=(RenderStack&&) = delete;
 
   /**
-   * @brief Updates panel positions & data.
+   * @brief State update hook. Default is a no-op.
    *
+   * Called by Renderer before doRender() each frame. Override to update
+   * any derived-class state that must be refreshed before drawing.
    */
-  void doUpdate();
+  virtual void doUpdate() {};
 
   /**
-   * @brief Renders stack on terminal.
+   * @brief Draw this layer's content on the WINDOW.
    *
    */
-  void doRender();
+  virtual void doRender() = 0;
+
+  /**
+   * @brief Enable or disable this layer. Disabled layers are skipped entirely
+   * by Renderer::compose().
+   *
+   * @param e True to enable, false to disable.
+   */
+  void setEnabled(bool e) { enabled = e; };
+
+  /**
+   * @brief Check whether this layer is currently enabled.
+   *
+   * @return bool
+   */
+  bool isEnabled() const { return enabled; };
+
+  /**
+   * @brief Get the WINDOW.
+   *
+   * @return WINDOW*
+   */
+  WINDOW* getWindow() const { return win; };
+
+ protected:
+  WINDOW* win;
+  const int height;
+  const int width;
 
  private:
-  std::vector<PANEL*> panels;
+  bool enabled = true;
 };
 
 #endif

--- a/include/render_stack.h
+++ b/include/render_stack.h
@@ -1,0 +1,34 @@
+#ifndef RENDER_STACK_H
+#define RENDER_STACK_H
+
+#include <ncurses.h>
+#include <panel.h>
+
+#include <vector>
+
+class RenderStack {
+ public:
+  /**
+   * @brief Construct a new Render Stack object.
+   *
+   * @param panels Panel objects to render groupwise.
+   */
+  RenderStack(std::vector<PANEL*> panels) : panels(panels) {};
+
+  /**
+   * @brief Updates panel positions & data.
+   *
+   */
+  void doUpdate();
+
+  /**
+   * @brief Renders stack on terminal.
+   *
+   */
+  void doRender();
+
+ private:
+  std::vector<PANEL*> panels;
+};
+
+#endif

--- a/include/renderer.h
+++ b/include/renderer.h
@@ -1,0 +1,34 @@
+#ifndef RENDERER_H
+#define RENDERER_H
+
+#include <map>
+
+#include "render_stack.h"
+
+class Renderer {
+ public:
+  /**
+   * @brief Add a rendering layer at a given an index (z-order).
+   *
+   * Layers are composited in ascending key order: lower index = closer to
+   * the bottom.
+   *
+   * NOTE: if layer is added on same index as another layer, the current layer
+   * is replaced with the new one.
+   *
+   * @param z Z-order index.
+   * @param layer RenderStack layer to add.
+   */
+  void addLayer(int z, std::unique_ptr<RenderStack> layer);
+
+  /**
+   * @brief Composite all enabled layers onto stdscr and flush to terminal.
+   *
+   */
+  void compose();
+
+ private:
+  std::map<int, std::unique_ptr<RenderStack>> layers;
+};
+
+#endif

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -29,16 +29,18 @@ void Game::run() {
 
     // -------- Frame end --------
     auto end = std::chrono::high_resolution_clock::now();
-    auto elapsed = end - start;
+    auto elapsed =
+        std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
 
-    // TODO: Sleep to maintain consistent frame rate (there may be a better
-    // solution)
     if (elapsed < frame_duration) {
-      auto sleep_time =
-          frame_duration -
-          std::chrono::duration_cast<std::chrono::milliseconds>(elapsed);
-      std::this_thread::sleep_for(sleep_time);
+      std::this_thread::sleep_for(frame_duration - elapsed);
     }
+
+    // for debug window.
+    std::chrono::duration<double, std::milli> totalFrame =
+        std::chrono::high_resolution_clock::now() - start;
+
+    currentFps = totalFrame.count() > 0.0 ? 1000.0 / totalFrame.count() : 0.0;
   }
 
   endwin();
@@ -99,36 +101,7 @@ void Game::update() {
   }
 }
 
-void Game::render() {
-  clear();
-  box(stdscr, 0, 0);
-  const Room& room = level.getCurrentRoom();
-  for (int x = 0; x < Room::WIDTH; ++x) {
-    for (int y = 0; y < Room::HEIGHT; ++y) {
-      const Tile& tile = room.tiles[x][y];
-      mvaddch(tile.getPosition().y, tile.getPosition().x, tile.getSymbol());
-    }
-  }
-
-  // Draw player... if alive.
-  if (player.isAlive()) {
-    Coordinate playerPos = player.getPosition();
-    mvaddch(playerPos.y, playerPos.x, '@');
-  }
-
-  // Draw enemies
-  for (const auto& enemy : enemies) {
-    if (enemy->isAlive()) {
-      Coordinate enemyPos = enemy->getPosition();
-      mvaddch(enemyPos.y, enemyPos.x, enemy->getSymbol());
-    }
-  }
-
-  // Draw UI
-  mvprintw(0, 0, "HP: %d/%d", player.getHealth(), player.getMaxHealth());
-
-  refresh();
-}
+void Game::render() { renderer.compose(); };
 
 void Game::spawnEnemies() {
   enemies.push_back(std::make_unique<Enemy>(10, 10, 'G'));

--- a/src/layers/debug_layer.cpp
+++ b/src/layers/debug_layer.cpp
@@ -1,0 +1,8 @@
+#include "layers/debug_layer.h"
+
+void DebugLayer::doRender() {
+  werase(win);  // need to erase each frame.
+
+  mvwprintw(win, height - 1, 0, "FPS:%d.%.2f (%d,%d)", fps, frameTimeMs,
+            playerPos.x, playerPos.y);
+};

--- a/src/layers/debug_layer.cpp
+++ b/src/layers/debug_layer.cpp
@@ -3,6 +3,6 @@
 void DebugLayer::doRender() {
   werase(win);  // need to erase each frame.
 
-  mvwprintw(win, height - 1, 0, "FPS:%d.%.2f (%d,%d)", fps, frameTimeMs,
+  mvwprintw(win, height - 1, 0, "FPS:%d.%d (%d,%d)", fps, frameTimeMs,
             playerPos.x, playerPos.y);
 };

--- a/src/layers/debug_layer.cpp
+++ b/src/layers/debug_layer.cpp
@@ -3,6 +3,7 @@
 void DebugLayer::doRender() {
   werase(win);  // need to erase each frame.
 
-  mvwprintw(win, height - 1, 0, "FPS:%d.%d (%d,%d)", fps, frameTimeMs,
-            playerPos.x, playerPos.y);
+  Coordinate pos = player.getPosition();
+  mvwprintw(win, height - 1, 0, "FPS:%.2f|Position:(%d,%d)", currentFps, pos.x,
+            pos.y);
 };

--- a/src/layers/entity_layer.cpp
+++ b/src/layers/entity_layer.cpp
@@ -2,6 +2,8 @@
 
 #include <ncurses.h>
 
+#include <memory>
+
 void EntityLayer::drawEnemies() {
   // iterate through vector of enemies.
   for (const auto& enemy : enemies) {

--- a/src/layers/entity_layer.cpp
+++ b/src/layers/entity_layer.cpp
@@ -1,0 +1,34 @@
+#include "layers/entity_layer.h"
+
+#include <ncurses.h>
+
+void EntityLayer::drawEnemies() {
+  // iterate through vector of enemies.
+  for (const auto& enemy : enemies) {
+    // if alive, draw symbol.
+    if (enemy->isAlive()) {
+      Coordinate pos = enemy->getPosition();
+
+      mvwaddch(win, pos.y, pos.x, enemy->getSymbol());
+    };
+    // TODO: if enemy dead, destroy the object & update the vector? lil
+    // optimization??
+  };
+};
+
+void EntityLayer::drawPlayer() {
+  // if alive, draw symbol.
+  if (player.isAlive()) {
+    Coordinate pos = player.getPosition();
+
+    mvwaddch(win, pos.y, pos.x, player.getSymbol());
+  };
+};
+
+void EntityLayer::doRender() {
+  werase(win);  // need to erase each frame.
+
+  // render enemies first, then player (top of render).
+  this->drawEnemies();
+  this->drawPlayer();
+};

--- a/src/layers/hud_layer.cpp
+++ b/src/layers/hud_layer.cpp
@@ -2,7 +2,7 @@
 
 #include <ncurses.h>
 
-void HUDLayer::drawPlayerHealthBar(int offsetX = 0, int offsetY = 1) {
+void HUDLayer::drawPlayerHealthBar(int offsetX, int offsetY) {
   // only draw if the position isn't ontop of player.
   // TODO: add a warning log if this is ever true?
   if (offsetX != 0 or offsetY != 0) {

--- a/src/layers/hud_layer.cpp
+++ b/src/layers/hud_layer.cpp
@@ -1,0 +1,26 @@
+#include "layers/hud_layer.h"
+
+#include <ncurses.h>
+
+void HUDLayer::drawPlayerHealthBar(int offsetX = 0, int offsetY = 1) {
+  // only draw if the position isn't ontop of player.
+  // TODO: add a warning log if this is ever true?
+  if (offsetX != 0 or offsetY != 0) {
+    // get the player's current position.
+    Coordinate pos = player.getPosition();
+
+    // get the absolute position to draw the health bar.
+    int barX = pos.x - offsetX;
+    int barY = pos.y - offsetY;
+
+    mvwprintw(win, barY, barX, "HP:%d/%d", player.getHealth(),
+              player.getMaxHealth());
+  };
+};
+
+void HUDLayer::doRender() {
+  werase(win);  // need to erase each frame.
+
+  // draw player health bar.
+  this->drawPlayerHealthBar();
+};

--- a/src/layers/map_layer.cpp
+++ b/src/layers/map_layer.cpp
@@ -1,0 +1,29 @@
+#include "layers/map_layer.h"
+
+#include <ncurses.h>
+
+#include "room.h"
+
+void MapLayer::drawMap() {
+  const Room& room = level.getCurrentRoom();
+
+  for (int x = 0; x < Room::WIDTH; ++x) {
+    for (int y = 0; y < Room::HEIGHT; ++y) {
+      // get tile reference & print it.
+      const Tile& tile = room.tiles[x][y];
+
+      mvwaddch(win, tile.getPosition().y, tile.getPosition().x,
+               tile.getSymbol());
+    };
+  };
+};
+
+void MapLayer::doRender() {
+  werase(win);  // need to erase each frame.
+
+  // boarder around map.
+  box(win, 0, 0);
+
+  // draw map.
+  this->drawMap();
+};

--- a/src/render_stack.cpp
+++ b/src/render_stack.cpp
@@ -1,0 +1,5 @@
+#include <render_stack.h>
+
+void RenderStack::doRender() {};
+
+void RenderStack::doUpdate() {};

--- a/src/render_stack.cpp
+++ b/src/render_stack.cpp
@@ -1,5 +1,0 @@
-#include <render_stack.h>
-
-void RenderStack::doRender() {};
-
-void RenderStack::doUpdate() {};

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -1,0 +1,25 @@
+#include "renderer.h"
+
+#include <ncurses.h>
+
+void Renderer::addLayer(int z, std::unique_ptr<RenderStack> layer) {
+  layers[z] = std::move(layer);
+};
+
+void Renderer::compose() {
+  erase();  // erase stdscr first.
+
+  // iterate through the "layers", update them, render, and then layer them.
+  for (auto& [z, layer] : layers) {
+    if (layer->isEnabled()) {
+      layer->doUpdate();
+      layer->doRender();
+
+      // overlay the ncurses::WINDOW object.
+      overlay(layer->getWindow(), stdscr);
+    };
+  };
+
+  // flush to terminal.
+  refresh();
+};


### PR DESCRIPTION
## Summary

Adding functional window overlays. Also added a simple debug window.

---

## Related Issues

Closes #33 & #36 

---

## Changes Made

- Added an abstract `RenderStack` object that initializes a `ncurses::WINDOW` for a given "layer".
- Added 4 types of layers (inheriting the `RenderStack`):
  - **`MapLayer`:** Base window overlay. Holds & renders the map. Initialized with the `Level` reference.
  - **`EntityLayer`:** The second window overlay. Draws & renders the players & enemies (NOTE: enemies rendered first, then player. So if the player is on top of another enemy, they are rendered on top). Initialized via a reference to the `Player` object and a reference to the vector of unique `Enemy` pointers.
  - **`HUDLayer`:** This is the third window overlay. It currently only renders/draws the player's health. But it would be used for intractable objects, etc. Initialized by a ref to the `Player` object.
  - **`DebugLayer`:** The last window overlay (for now). Currently just rendering the current FPS and the player position in terms of (row, column). Initialized by passing references of the `Game::currentFps` (new) & the `Player` object.
- Created a `Renderer`. No initialization/constructor. Has a method to add a layer w/ z-order indexing.
- Refactored `Game` to have `currentFps` & `renderer`. NOTE: I wrote this in one of my comments, but I am currently ordering the layers via the `Game` constructor and just passing the z-order index. Probably want to create an `Enum` here instead, so if we add more overlays in the future, we only have to change the `Enum` instead of each index of each added layer. -- particularly important because adding a layer to an index that already has a layer just overrides the existing layer.

---

## Notes

Several to-dos are still at play. Wrote most of them as comments.

Should think of a better way to control FPS. Current FPS (via the debug overlay) says we are about 10 frames behind our target FPS (60fps).

Will want to create debug & prod builds. I wrote a comment about how to do this. Very simple. Just don't know how to implement via `cmake`. See issue number 32.

**Would rec a squash merge.**