### PR TITLE
docs: Removing TODO comment & adjusting comment for debug build

### DIFF
--- a/include/game.h
+++ b/include/game.h
@@ -48,9 +48,7 @@ class Game {
     renderer.addLayer(
         3, std::make_unique<HUDLayer>(screenHeight, screenWidth, player));
 
-    // if not prod, add the debug window.
-    // TODO: create debug & prod builds. <-- `NDEBUG` (no debug) can be enabled
-    // via a build flag: `-DNDEBUG`.
+    // if debug build, add the debug window.
 #ifndef NDEBUG
     renderer.addLayer(4, std::make_unique<DebugLayer>(screenHeight, screenWidth,
                                                       currentFps, player));


### PR DESCRIPTION
## Summary

Don't actually need to make any changes to the code to create debug & release builds. Instead, **delete your current "./build" directory** then do the following:

```bash
# create debug build.
cmake -B .build/debug -DCMAKE_BUILD_TYPE=Debug
cmake --build .build/debug

# create a release build.
cmake -B .build/release -DCMAKE_BUILD_TYPE=Release
cmake --build .build/release
```

The `.build/debug/roguelike` build should have the debug window overlay, and `.build/release/roguelike` should not have this overlay.    

---

## Related Issues

Closes #32 

---

## Changes Made

- Removed the TODO comment & adjusted debug overlay comment.

---

## Notes

Hitta rebase merge.