### PR TITLE
refactor: Moving constructor defs out of header files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(Curses REQUIRED)
 set(SOURCES
     src/main.cpp
     src/game.cpp
+    src/entity.cpp
     src/player.cpp
     src/enemy.cpp
     src/level.cpp
@@ -19,6 +20,7 @@ set(SOURCES
     src/tile.cpp
     src/room.cpp
     src/renderer.cpp
+    src/render_stack.cpp
     src/logger.cpp
     src/layers/map_layer.cpp
     src/layers/entity_layer.cpp

--- a/include/enemy.h
+++ b/include/enemy.h
@@ -21,10 +21,7 @@ class Enemy : public Entity {
    * rx = 20, ry = 10.
    */
   Enemy(int x, int y, char symbol = 'E', int health = 100, int speed = 10,
-        int attackDamage = 10, FOV attackFOV = ellipseFOV(20, 10))
-      : Entity(x, y, symbol, health, speed),
-        attackDamage(attackDamage),
-        attackFOV(attackFOV) {};
+        int attackDamage = 10, FOV attackFOV = ellipseFOV(20, 10));
 
   /**
    * @brief Get the enemy's attack damage.

--- a/include/entity.h
+++ b/include/entity.h
@@ -5,12 +5,7 @@
 
 class Entity {
  public:
-  Entity(int x, int y, char symbol, int health, int speed)
-      : position(x, y),
-        symbol(symbol),
-        health(health),
-        speed(speed),
-        frameCounter(0) {};
+  Entity(int x, int y, char symbol, int health, int speed);
 
   virtual ~Entity() = default;
 

--- a/include/fov.h
+++ b/include/fov.h
@@ -17,7 +17,7 @@ class FOV {
    * FOV.
    *
    */
-  FOV(std::set<Coordinate> offsets) : offsets(std::move(offsets)) {};
+  FOV(std::set<Coordinate> offsets);
 
   /**
    * @brief Determine if a position is in an origin's FOV.

--- a/include/game.h
+++ b/include/game.h
@@ -29,31 +29,7 @@ class Game {
    * spawns enemies, and builds the render layer stack.
    *
    */
-  Game(int width = 175, int height = 50, int fps = 60)
-      : screenWidth(width),
-        screenHeight(height),
-        fps(fps),
-        player(width / 2, height / 2),
-        level(5),
-        isRunning(true) {
-    // generate enemy objects first..
-    spawnEnemies();
-
-    // add window overlays.
-    // TODO: probably want to create an Enum for layer ordering.
-    renderer.addLayer(
-        1, std::make_unique<MapLayer>(screenHeight, screenWidth, level));
-    renderer.addLayer(2, std::make_unique<EntityLayer>(
-                             screenHeight, screenWidth, player, enemies));
-    renderer.addLayer(3, std::make_unique<HUDLayer>(screenHeight, screenWidth,
-                                                    player, level));
-
-    // if debug build, add the debug window.
-#ifndef NDEBUG
-    renderer.addLayer(4, std::make_unique<DebugLayer>(screenHeight, screenWidth,
-                                                      currentFps, player));
-#endif
-  };
+  Game(int width = 175, int height = 50, int fps = 60);
 
   /**
    * @brief Runs the main game loop.

--- a/include/layers/debug_layer.h
+++ b/include/layers/debug_layer.h
@@ -14,8 +14,7 @@ class DebugLayer : public RenderStack {
    * @param currentFps Current frames-per-second game is rendering at.
    * @param player The player object.
    */
-  DebugLayer(int h, int w, const double& currentFps, const Player& player)
-      : RenderStack(h, w), currentFps(currentFps), player(player) {};
+  DebugLayer(int h, int w, const double& currentFps, const Player& player);
 
   /**
    * @brief Draw frame timing and player position at the bottom row.

--- a/include/layers/entity_layer.h
+++ b/include/layers/entity_layer.h
@@ -23,8 +23,7 @@ class EntityLayer : public RenderStack {
    * @param enemies The enemy list to draw each frame.
    */
   EntityLayer(int h, int w, const Player& player,
-              const std::vector<std::unique_ptr<Enemy>>& enemies)
-      : RenderStack(h, w), player(player), enemies(enemies) {};
+              const std::vector<std::unique_ptr<Enemy>>& enemies);
 
   /**
    * @brief Draw enemy entities.

--- a/include/layers/hud_layer.h
+++ b/include/layers/hud_layer.h
@@ -15,8 +15,7 @@ class HUDLayer : public RenderStack {
    * @param player The player object to track stats, health, position, etc.
    * @param level  The level to read the current room ID from.
    */
-  HUDLayer(int h, int w, const Player& player, const Level& level)
-      : RenderStack(h, w), player(player), level(level) {};
+  HUDLayer(int h, int w, const Player& player, const Level& level);
 
   /**
    * @brief Draw player health bar.

--- a/include/layers/map_layer.h
+++ b/include/layers/map_layer.h
@@ -13,8 +13,7 @@ class MapLayer : public RenderStack {
    * @param w Width of the layer window (in columns).
    * @param level The level class whose current room will be drawn each frame.
    */
-  MapLayer(int h, int w, const Level& level)
-      : RenderStack(h, w), level(level) {};
+  MapLayer(int h, int w, const Level& level);
 
   /**
    * @brief Draw all room tiles into the map layer window.

--- a/include/level.h
+++ b/include/level.h
@@ -34,7 +34,7 @@ class Level {
    *
    * @param roomCount Number of rooms to generate.
    */
-  Level(int roomCount) : roomCount(roomCount) { generate(); }
+  Level(int roomCount);
 
   /**
    * @brief Add a room to the level.

--- a/include/player.h
+++ b/include/player.h
@@ -15,8 +15,7 @@ class Player : public Entity {
    * @param speed Frames per move. For example, speed = 2, means a player can
    * move per every 2 frames/renders. By default, equal to 1.
    */
-  Player(int x, int y, int health = 100, int speed = 1)
-      : Entity(x, y, '@', health, speed), maxHealth(health) {};
+  Player(int x, int y, int health = 100, int speed = 1);
 
   /**
    * @brief Get the initial max health of player.

--- a/include/render_stack.h
+++ b/include/render_stack.h
@@ -11,7 +11,7 @@ class RenderStack {
    * @param h Height of the layer window (in rows).
    * @param w Width of the layer window (in columns).
    */
-  RenderStack(int h, int w) : win(newwin(h, w, 0, 0)), height(h), width(w) {};
+  RenderStack(int h, int w);
 
   // need to make sure the ncurses::WINDOW is deleted if object is.
   virtual ~RenderStack() {

--- a/include/room.h
+++ b/include/room.h
@@ -40,7 +40,7 @@ struct Room {
    *
    * @param id Unique room identifier.
    */
-  Room(int id) : roomID(id), tiles(WIDTH, std::vector<Tile>(HEIGHT)) {}
+  Room(int id);
 
   /**
    * @brief Procedurally generate a Room with the given shape.

--- a/include/tile.h
+++ b/include/tile.h
@@ -22,8 +22,7 @@ class Tile {
    * @param type Type of tile. By default, TileType::Wall.
    * @param position Position of tile.
    */
-  Tile(TileType type = TileType::Wall, Coordinate position = Coordinate(0, 0))
-      : type(type), position(position) {};
+  Tile(TileType type = TileType::Wall, Coordinate position = Coordinate(0, 0));
 
   /**
    * @brief Get the tile symbol.

--- a/src/enemy.cpp
+++ b/src/enemy.cpp
@@ -6,6 +6,12 @@
 
 #include "coordinate.h"
 
+Enemy::Enemy(int x, int y, char symbol, int health, int speed, int attackDamage,
+             FOV attackFOV)
+    : Entity(x, y, symbol, health, speed),
+      attackDamage(attackDamage),
+      attackFOV(attackFOV) {}
+
 void Enemy::moveTowardPlayer(Coordinate playerPos) {
   // only move toward player if in FOV.
   if (attackFOV.in(position, playerPos)) {

--- a/src/entity.cpp
+++ b/src/entity.cpp
@@ -1,0 +1,8 @@
+#include "entity.h"
+
+Entity::Entity(int x, int y, char symbol, int health, int speed)
+    : position(x, y),
+      symbol(symbol),
+      health(health),
+      speed(speed),
+      frameCounter(0) {}

--- a/src/fov.cpp
+++ b/src/fov.cpp
@@ -3,7 +3,10 @@
 
 #include <cmath>
 #include <set>
+#include <utility>
 #include <vector>
+
+FOV::FOV(std::set<Coordinate> offsets) : offsets(std::move(offsets)) {}
 
 bool FOV::in(Coordinate origin, Coordinate position) const {
   Coordinate offset = origin - position;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -9,6 +9,32 @@
 
 #include "enemy.h"
 
+Game::Game(int width, int height, int fps)
+    : screenWidth(width),
+      screenHeight(height),
+      fps(fps),
+      player(width / 2, height / 2),
+      level(5),
+      isRunning(true) {
+  // generate enemy objects first..
+  spawnEnemies();
+
+  // add window overlays.
+  // TODO: probably want to create an Enum for layer ordering.
+  renderer.addLayer(
+      1, std::make_unique<MapLayer>(screenHeight, screenWidth, level));
+  renderer.addLayer(2, std::make_unique<EntityLayer>(screenHeight, screenWidth,
+                                                     player, enemies));
+  renderer.addLayer(
+      3, std::make_unique<HUDLayer>(screenHeight, screenWidth, player, level));
+
+  // if debug build, add the debug window.
+#ifndef NDEBUG
+  renderer.addLayer(4, std::make_unique<DebugLayer>(screenHeight, screenWidth,
+                                                    currentFps, player));
+#endif
+}
+
 void Game::run() {
   printw("Roguelike Game Started! Use arrow keys to move. Press Q to quit.\n");
   printw("Press SPACE to begin...\n");

--- a/src/layers/debug_layer.cpp
+++ b/src/layers/debug_layer.cpp
@@ -1,5 +1,9 @@
 #include "layers/debug_layer.h"
 
+DebugLayer::DebugLayer(int h, int w, const double& currentFps,
+                       const Player& player)
+    : RenderStack(h, w), currentFps(currentFps), player(player) {}
+
 void DebugLayer::doRender() {
   werase(win);  // need to erase each frame.
 

--- a/src/layers/entity_layer.cpp
+++ b/src/layers/entity_layer.cpp
@@ -4,6 +4,10 @@
 
 #include <memory>
 
+EntityLayer::EntityLayer(int h, int w, const Player& player,
+                          const std::vector<std::unique_ptr<Enemy>>& enemies)
+    : RenderStack(h, w), player(player), enemies(enemies) {}
+
 void EntityLayer::drawEnemies() {
   // iterate through vector of enemies.
   for (const auto& enemy : enemies) {

--- a/src/layers/hud_layer.cpp
+++ b/src/layers/hud_layer.cpp
@@ -2,6 +2,9 @@
 
 #include <ncurses.h>
 
+HUDLayer::HUDLayer(int h, int w, const Player& player, const Level& level)
+    : RenderStack(h, w), player(player), level(level) {}
+
 void HUDLayer::drawPlayerHealthBar(int offsetX, int offsetY) {
   // only draw if the position isn't ontop of player.
   // TODO: add a warning log if this is ever true?

--- a/src/layers/map_layer.cpp
+++ b/src/layers/map_layer.cpp
@@ -4,6 +4,9 @@
 
 #include "room.h"
 
+MapLayer::MapLayer(int h, int w, const Level& level)
+    : RenderStack(h, w), level(level) {}
+
 void MapLayer::drawMap() {
   const Room& room = level.getCurrentRoom();
 

--- a/src/level.cpp
+++ b/src/level.cpp
@@ -5,6 +5,8 @@
 
 #include "tile.h"
 
+Level::Level(int roomCount) : roomCount(roomCount) { generate(); }
+
 void Level::addRoom(Room room) {
   int id = room.roomID;
   roomList.insert({id, std::move(room)});

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -2,6 +2,9 @@
 
 #include "coordinate.h"
 
+Player::Player(int x, int y, int health, int speed)
+    : Entity(x, y, '@', health, speed), maxHealth(health) {}
+
 void Player::takeDamage(int damage) {
   health -= damage;
   if (health < 0) health = 0;

--- a/src/render_stack.cpp
+++ b/src/render_stack.cpp
@@ -1,0 +1,4 @@
+#include "render_stack.h"
+
+RenderStack::RenderStack(int h, int w)
+    : win(newwin(h, w, 0, 0)), height(h), width(w) {}

--- a/src/room.cpp
+++ b/src/room.cpp
@@ -13,6 +13,8 @@ void fillRect(Room& room, int x1, int y1, int x2, int y2) {
 
 }  // namespace
 
+Room::Room(int id) : roomID(id), tiles(WIDTH, std::vector<Tile>(HEIGHT)) {}
+
 Room Room::generate(int roomID, RoomShape shape) {
   Room room(roomID);
 

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -1,5 +1,8 @@
 #include "tile.h"
 
+Tile::Tile(TileType type, Coordinate position)
+    : type(type), position(position) {}
+
 // Define all tile types and their attributes in ONE place
 const std::unordered_map<int, TileAttributes> Tile::typeAttributes = {
     {static_cast<int>(TileType::Wall), {'#', false}},


### PR DESCRIPTION
## Summary

Moved constructor definitions out of header files, into corresponding source files. Left forward declarations & docstrings in headers.

---

## Related Issues

Closes #46 

---

## Changes Made

- Moved all constructor definitions in `include/**` --> `src/**`.

---

## Notes

Hitta **squash merge**.