### PR TITLE
feat: Replacing '.' character with space character for room floor til…

### DIFF
--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -6,9 +6,9 @@ Tile::Tile(TileType type, Coordinate position)
 // Define all tile types and their attributes in ONE place
 const std::unordered_map<int, TileAttributes> Tile::typeAttributes = {
     {static_cast<int>(TileType::Wall), {'#', false}},
-    {static_cast<int>(TileType::Floor), {'.', true}},
+    {static_cast<int>(TileType::Floor), {' ', true}},
     {static_cast<int>(TileType::Door), {'+', true}},
-    {static_cast<int>(TileType::Void), {' ', false}},
+    {static_cast<int>(TileType::Void), {'.', false}},
 };
 
 char Tile::getSymbol() const {


### PR DESCRIPTION


## Summary

 Replacing '.' character with space character for room floor tile type

---

## Related Issues

Closes #

---

## Changes Made

- 

---

## Notes

