### PR TITLE
feat: Dynamically centered map; HUD layer margin

### DIFF
--- a/include/game.h
+++ b/include/game.h
@@ -21,12 +21,9 @@ class Game {
   /**
    * @brief Construct a new Game:: Game object.
    *
-   * @param width width of the game screen.
-   * @param height height of the game screen.
+   * @param width Current terminal width (columns).
+   * @param height Current terminal height (rows).
    * @param fps frames per second of game. By default, 60.
-   *
-   * Initializes the player in the center of the screen, generates the level,
-   * spawns enemies, and builds the render layer stack.
    *
    */
   Game(int width, int height, int fps = 60);
@@ -40,7 +37,7 @@ class Game {
   void run();
 
  private:
-  const int screenWidth, screenHeight;
+  int termWidth, termHeight;
   const int fps;
   double currentFps;
   Player player;

--- a/include/game.h
+++ b/include/game.h
@@ -21,15 +21,15 @@ class Game {
   /**
    * @brief Construct a new Game:: Game object.
    *
-   * @param width width of the game screen. By default, 175.
-   * @param height height of the game screen. By default, 50.
+   * @param width width of the game screen.
+   * @param height height of the game screen.
    * @param fps frames per second of game. By default, 60.
    *
    * Initializes the player in the center of the screen, generates the level,
    * spawns enemies, and builds the render layer stack.
    *
    */
-  Game(int width = 175, int height = 50, int fps = 60);
+  Game(int width, int height, int fps = 60);
 
   /**
    * @brief Runs the main game loop.

--- a/include/layers/entity_layer.h
+++ b/include/layers/entity_layer.h
@@ -19,10 +19,12 @@ class EntityLayer : public RenderStack {
    *
    * @param h Height of the layer window (in rows).
    * @param w Width of the layer window (in columns).
+   * @param y Row of the window's top-left corner in the terminal.
+   * @param x Column of the window's top-left corner in the terminal.
    * @param player The player entity to draw each frame.
    * @param enemies The enemy list to draw each frame.
    */
-  EntityLayer(int h, int w, const Player& player,
+  EntityLayer(int h, int w, int y, int x, const Player& player,
               const std::vector<std::unique_ptr<Enemy>>& enemies);
 
   /**
@@ -42,6 +44,14 @@ class EntityLayer : public RenderStack {
    *
    */
   void doRender() override;
+
+  /**
+   * @brief Recompute the centered, terminal-clamped map window geometry.
+   *
+   * @param termHeight New terminal height (rows).
+   * @param termWidth New terminal width (columns).
+   */
+  void onResize(int termHeight, int termWidth) override;
 
  private:
   const Player& player;

--- a/include/layers/hud_layer.h
+++ b/include/layers/hud_layer.h
@@ -12,30 +12,29 @@ class HUDLayer : public RenderStack {
    *
    * @param h      Height of the layer window (in rows).
    * @param w      Width of the layer window in columns.
+   * @param margin The margin between HUD & map layer.
    * @param player The player object to track stats, health, position, etc.
    * @param level  The level to read the current room ID from.
    */
-  HUDLayer(int h, int w, const Player& player, const Level& level);
+  HUDLayer(int h, int w, const int margin, const Player& player,
+           const Level& level);
 
   /**
-   * @brief Draw player health bar.
+   * @brief Draw player health bar at a fixed screen position.
    *
-   * Defaults to being drawn directly above player position.
-   *
-   * @param offsetX The offset x (column) position (relative to player) to draw
-   * health bar. Positive offsets shift bar left, negative offsets shift bar
-   * right. By default, 0.
-   * @param offsetY The offset y (row) position (relative to player) to draw
-   * health bar. Positive offsets shift bar up, negative offsets shift bar
-   * down. By default, 1.
+   * @param row Absolute row to draw the health bar at.
+   * @param col Absolute column to draw the health bar at.
    */
-  void drawPlayerHealthBar(int offsetX = 0, int offsetY = 1);
+  void drawPlayerHealthBar(int row, int col);
 
   /**
-   * @brief Draw the current room ID and total room count in the top-left
-   * corner of the screen.
+   * @brief Draw the current room ID and total room count at a fixed screen
+   * position.
+   *
+   * @param row Absolute row to draw the room indicator at.
+   * @param col Absolute column to draw the room indicator at.
    */
-  void drawRoomID();
+  void drawRoomID(int row, int col);
 
   /**
    * @brief Draw the HP indicator and room ID each frame.
@@ -46,6 +45,7 @@ class HUDLayer : public RenderStack {
  private:
   const Player& player;
   const Level& level;
+  const int margin;
 };
 
 #endif

--- a/include/layers/map_layer.h
+++ b/include/layers/map_layer.h
@@ -11,9 +11,11 @@ class MapLayer : public RenderStack {
    *
    * @param h Height of the layer window (in rows).
    * @param w Width of the layer window (in columns).
+   * @param y Row of the window's top-left corner in the terminal.
+   * @param x Column of the window's top-left corner in the terminal.
    * @param level The level class whose current room will be drawn each frame.
    */
-  MapLayer(int h, int w, const Level& level);
+  MapLayer(int h, int w, int y, int x, const Level& level);
 
   /**
    * @brief Draw all room tiles into the map layer window.
@@ -26,6 +28,14 @@ class MapLayer : public RenderStack {
    *
    */
   void doRender() override;
+
+  /**
+   * @brief Recompute the centered, terminal-clamped map window geometry.
+   *
+   * @param termHeight New terminal height (rows).
+   * @param termWidth New terminal width (columns).
+   */
+  void onResize(int termHeight, int termWidth) override;
 
  private:
   const Level& level;

--- a/include/render_stack.h
+++ b/include/render_stack.h
@@ -10,8 +10,12 @@ class RenderStack {
    *
    * @param h Height of the layer window (in rows).
    * @param w Width of the layer window (in columns).
+   * @param y Row of the window's top-left corner in the terminal. By
+   * default, 0.
+   * @param x Column of the window's top-left corner in the terminal. By
+   * default, 0.
    */
-  RenderStack(int h, int w);
+  RenderStack(int h, int w, int y = 0, int x = 0);
 
   // need to make sure the ncurses::WINDOW is deleted if object is.
   virtual ~RenderStack() {
@@ -31,6 +35,17 @@ class RenderStack {
    * any derived-class state that must be refreshed before drawing.
    */
   virtual void doUpdate() {};
+
+  /**
+   * @brief Terminal-resize hook. Default recreates the window to span the
+   * full terminal at origin (0,0).
+   *
+   * @param termHeight New terminal height (rows).
+   * @param termWidth New terminal width (columns).
+   */
+  virtual void onResize(int termHeight, int termWidth) {
+    reshape(termHeight, termWidth, 0, 0);
+  }
 
   /**
    * @brief Draw this layer's content on the WINDOW.
@@ -61,9 +76,21 @@ class RenderStack {
   WINDOW* getWindow() const { return win; };
 
  protected:
+  /**
+   * @brief Recreate the window with a new size/origin.
+   *
+   * @param h New height (in rows).
+   * @param w New width (in columns).
+   * @param y New row of the window's top-left corner. By default, 0.
+   * @param x New column of the window's top-left corner. By default, 0.
+   */
+  void reshape(int h, int w, int y = 0, int x = 0);
+
   WINDOW* win;
-  const int height;
-  const int width;
+  int height;
+  int width;
+  int originY;
+  int originX;
 
  private:
   bool enabled = true;

--- a/include/renderer.h
+++ b/include/renderer.h
@@ -28,6 +28,14 @@ class Renderer {
    */
   void compose();
 
+  /**
+   * @brief Resize all layers to a terminal resize.
+   *
+   * @param termHeight New terminal height (rows).
+   * @param termWidth New terminal width (columns).
+   */
+  void resizeAll(int termHeight, int termWidth);
+
  private:
   std::map<int, std::unique_ptr<RenderStack>> layers;
 };

--- a/include/ui.h
+++ b/include/ui.h
@@ -1,0 +1,29 @@
+#ifndef UI_H
+#define UI_H
+
+#include <algorithm>
+
+#include "room.h"
+
+struct UI {
+  int winHeight, winWidth;  ///< Window size, clamped to the terminal size.
+  int originY, originX;     ///< Top-left of the map window in the terminal.
+};
+
+/**
+ * @brief Compute the centered, terminal-clamped map window UI geometry.
+ *
+ * @param termHeight Current terminal height (rows).
+ * @param termWidth  Current terminal width (columns).
+ * @return UI
+ */
+inline UI computeUI(int termHeight, int termWidth) {
+  UI g;
+  g.winHeight = std::min(Room::HEIGHT, termHeight);
+  g.winWidth = std::min(Room::WIDTH, termWidth);
+  g.originY = std::max(0, (termHeight - Room::HEIGHT) / 2);
+  g.originX = std::max(0, (termWidth - Room::WIDTH) / 2);
+  return g;
+}
+
+#endif

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8,12 +8,13 @@
 #include <thread>
 
 #include "enemy.h"
+#include "ui.h"
 
 Game::Game(int width, int height, int fps)
-    : screenWidth(width),
-      screenHeight(height),
+    : termWidth(width),
+      termHeight(height),
       fps(fps),
-      player(width / 2, height / 2),
+      player(Room::WIDTH / 2, Room::HEIGHT / 2),
       level(5),
       isRunning(true) {
   // generate enemy objects first..
@@ -21,16 +22,21 @@ Game::Game(int width, int height, int fps)
 
   // add window overlays.
   // TODO: probably want to create an Enum for layer ordering.
+  UI geom = computeUI(termHeight, termWidth);
   renderer.addLayer(
-      1, std::make_unique<MapLayer>(screenHeight, screenWidth, level));
-  renderer.addLayer(2, std::make_unique<EntityLayer>(screenHeight, screenWidth,
-                                                     player, enemies));
-  renderer.addLayer(
-      3, std::make_unique<HUDLayer>(screenHeight, screenWidth, player, level));
+      1, std::make_unique<MapLayer>(geom.winHeight, geom.winWidth, geom.originY,
+                                    geom.originX, level));
+  renderer.addLayer(2, std::make_unique<EntityLayer>(
+                           geom.winHeight, geom.winWidth, geom.originY,
+                           geom.originX, player, enemies));
+
+  const int hud_margin = 5;
+  renderer.addLayer(3, std::make_unique<HUDLayer>(termHeight, termWidth,
+                                                  hud_margin, player, level));
 
   // if debug build, add the debug window.
 #ifndef NDEBUG
-  renderer.addLayer(4, std::make_unique<DebugLayer>(screenHeight, screenWidth,
+  renderer.addLayer(4, std::make_unique<DebugLayer>(termHeight, termWidth,
                                                     currentFps, player));
 #endif
 }
@@ -78,6 +84,10 @@ void Game::handleInput() {
   Coordinate newPlayerPos = player.getPosition();
 
   switch (ch) {
+    case KEY_RESIZE:  // in case of a terminal resize.
+      getmaxyx(stdscr, termHeight, termWidth);
+      renderer.resizeAll(termHeight, termWidth);
+      return;
     case KEY_UP:
     case 'w':  // Up
       newPlayerPos.y -= 1;

--- a/src/layers/entity_layer.cpp
+++ b/src/layers/entity_layer.cpp
@@ -4,9 +4,11 @@
 
 #include <memory>
 
-EntityLayer::EntityLayer(int h, int w, const Player& player,
-                          const std::vector<std::unique_ptr<Enemy>>& enemies)
-    : RenderStack(h, w), player(player), enemies(enemies) {}
+#include "ui.h"
+
+EntityLayer::EntityLayer(int h, int w, int y, int x, const Player& player,
+                         const std::vector<std::unique_ptr<Enemy>>& enemies)
+    : RenderStack(h, w, y, x), player(player), enemies(enemies) {}
 
 void EntityLayer::drawEnemies() {
   // iterate through vector of enemies.
@@ -37,4 +39,9 @@ void EntityLayer::doRender() {
   // render enemies first, then player (top of render).
   this->drawEnemies();
   this->drawPlayer();
+};
+
+void EntityLayer::onResize(int termHeight, int termWidth) {
+  UI g = computeUI(termHeight, termWidth);
+  reshape(g.winHeight, g.winWidth, g.originY, g.originX);
 };

--- a/src/layers/hud_layer.cpp
+++ b/src/layers/hud_layer.cpp
@@ -2,37 +2,32 @@
 
 #include <ncurses.h>
 
-HUDLayer::HUDLayer(int h, int w, const Player& player, const Level& level)
-    : RenderStack(h, w), player(player), level(level) {}
+#include <algorithm>
 
-void HUDLayer::drawPlayerHealthBar(int offsetX, int offsetY) {
-  // only draw if the position isn't ontop of player.
-  // TODO: add a warning log if this is ever true?
-  if (offsetX != 0 or offsetY != 0) {
-    // get the player's current position.
-    Coordinate pos = player.getPosition();
+#include "ui.h"
 
-    // get the absolute position to draw the health bar.
-    int barX = pos.x - offsetX;
-    int barY = pos.y - offsetY;
+HUDLayer::HUDLayer(int h, int w, int margin, const Player& player,
+                   const Level& level)
+    : RenderStack(h, w), player(player), level(level), margin(margin) {}
 
-    mvwprintw(win, barY, barX, "HP:%d/%d", player.getHealth(),
-              player.getMaxHealth());
-  };
+void HUDLayer::drawPlayerHealthBar(int row, int col) {
+  mvwprintw(win, row, col, "HP:%d/%d", player.getHealth(),
+            player.getMaxHealth());
 };
 
-void HUDLayer::drawRoomID() {
-  // Display "Room X/N" fixed at the top-left corner of the screen.
-  mvwprintw(win, 0, 0, "Room:%d/%d", level.getCurrentRoomID() + 1,
+void HUDLayer::drawRoomID(int row, int col) {
+  mvwprintw(win, row, col, "Room:%d/%d", level.getCurrentRoomID() + 1,
             level.getRoomCount());
 };
 
 void HUDLayer::doRender() {
   werase(win);  // need to erase each frame.
 
-  // draw player health bar.
-  this->drawPlayerHealthBar();
+  // fixed HUD band above the map's top border, with a blank gap row
+  // separating the HUD text from the border itself.
+  UI geom = computeUI(height, width);
+  int bandRow = std::max(0, geom.originY - margin);
 
-  // draw current room indicator.
-  this->drawRoomID();
+  this->drawRoomID(bandRow, geom.originX);
+  this->drawPlayerHealthBar(bandRow + 1, geom.originX);
 };

--- a/src/layers/map_layer.cpp
+++ b/src/layers/map_layer.cpp
@@ -3,9 +3,10 @@
 #include <ncurses.h>
 
 #include "room.h"
+#include "ui.h"
 
-MapLayer::MapLayer(int h, int w, const Level& level)
-    : RenderStack(h, w), level(level) {}
+MapLayer::MapLayer(int h, int w, int y, int x, const Level& level)
+    : RenderStack(h, w, y, x), level(level) {}
 
 void MapLayer::drawMap() {
   const Room& room = level.getCurrentRoom();
@@ -29,4 +30,9 @@ void MapLayer::doRender() {
 
   // draw map.
   this->drawMap();
+};
+
+void MapLayer::onResize(int termHeight, int termWidth) {
+  UI g = computeUI(termHeight, termWidth);
+  reshape(g.winHeight, g.winWidth, g.originY, g.originX);
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,9 +5,6 @@
 
 #include "game.h"
 
-#define WIDTH 175
-#define HEIGHT 50
-
 int main() {
   // Seed the random number generator once at startup so room shapes, door
   // layouts, and enemy positions differ on every run.
@@ -26,7 +23,11 @@ int main() {
   curs_set(0);
 
   // get terminal size
-  Game game(WIDTH, HEIGHT);
+  int termHeight, termWidth;
+  getmaxyx(stdscr, termHeight, termWidth);
+
+  // start game.
+  Game game(termWidth, termHeight);
   game.run();
 
   return 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,12 +5,14 @@
 
 #include "game.h"
 
+#define WIDTH 175
+#define HEIGHT 50
+
 int main() {
   // Seed the random number generator once at startup so room shapes, door
   // layouts, and enemy positions differ on every run.
   srand(static_cast<unsigned int>(time(nullptr)));
 
-  int maxX, maxY;
   // Initialize ncurses
   initscr();
   cbreak();
@@ -24,8 +26,7 @@ int main() {
   curs_set(0);
 
   // get terminal size
-  getmaxyx(stdscr, maxY, maxX);
-  Game game(maxX, maxY);
+  Game game(WIDTH, HEIGHT);
   game.run();
 
   return 0;

--- a/src/render_stack.cpp
+++ b/src/render_stack.cpp
@@ -1,4 +1,13 @@
 #include "render_stack.h"
 
-RenderStack::RenderStack(int h, int w)
-    : win(newwin(h, w, 0, 0)), height(h), width(w) {}
+RenderStack::RenderStack(int h, int w, int y, int x)
+    : win(newwin(h, w, y, x)), height(h), width(w), originY(y), originX(x) {}
+
+void RenderStack::reshape(int h, int w, int y, int x) {
+  if (win) delwin(win);
+  win = newwin(h, w, y, x);
+  height = h;
+  width = w;
+  originY = y;
+  originX = x;
+}

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -23,3 +23,9 @@ void Renderer::compose() {
   // flush to terminal.
   refresh();
 };
+
+void Renderer::resizeAll(int termHeight, int termWidth) {
+  for (auto& [z, layer] : layers) {
+    layer->onResize(termHeight, termWidth);
+  };
+};


### PR DESCRIPTION
## Summary

Map is now centered based on the *current* terminal size. Also re-adjusts on resize. HUD layer now has a 5-row margin.

---

## Related Issues

Closes #66

---

## Changes Made

- Added a ``ui.h`` header file that computes the UI geometry based on terminal size & layer positioning.
- Resized & centered layers on resize via a ``ncurses`` "keystroke": ``KEY_RESIZE``
- Added a ``margin`` arg for the ``HUDLayer`` that adds a margin between map & the player HUD.
- Made the ``DebugLayer`` dynamic to the entire terminal size.

---

## Notes

Probably a **squash merge**. But idrc here.
