### PR TITLE
chore: Adding build scripts for streamlined building

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/scripts/build-debug.sh
+++ b/scripts/build-debug.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-cd "$(git rev-parse --show-toplevel)"
-cmake -B .build/debug -S . -DCMAKE_BUILD_TYPE=Debug
-cmake --build .build/debug

--- a/scripts/build-debug.sh
+++ b/scripts/build-debug.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+cmake -B .build/debug -S . -DCMAKE_BUILD_TYPE=Debug
+cmake --build .build/debug

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+cmake -B .build/release -S .
+cmake --build .build/release

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -1,0 +1,4 @@
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+cmake -B .build/release -S .
+cmake --build .build/release

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-cd "$(git rev-parse --show-toplevel)"
-cmake -B .build/release -S .
-cmake --build .build/release


### PR DESCRIPTION
## Summary

Adding scripts to make release & debug builds easier


---

## Changes Made

- Added a ``./scripts`` directory w/ bash scripts ``build-debug.sh`` & ``build-release.sh``

---

## Notes

Rebase merge.
