### PR TITLE
build: Adding ``ncursesw`` library

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,9 @@ project(Roguelike)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Find and configure ncurses.
+# Find and configure ncurses (wide-character build).
 set(CURSES_NEED_NCURSES TRUE)
+set(CURSES_NEED_WIDE TRUE)
 find_package(Curses REQUIRED)
 
 # Source files.

--- a/scripts/build-debug.sh
+++ b/scripts/build-debug.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-cd "$(git rev-parse --show-toplevel)"
-cmake -B .build/debug -S . -DCMAKE_BUILD_TYPE=Debug
-cmake --build .build/debug

--- a/scripts/build-debug.sh
+++ b/scripts/build-debug.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+cmake -B .build/debug -S . -DCMAKE_BUILD_TYPE=Debug
+cmake --build .build/debug

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+cmake -B .build/release -S .
+cmake --build .build/release

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -1,0 +1,4 @@
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+cmake -B .build/release -S .
+cmake --build .build/release

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-cd "$(git rev-parse --show-toplevel)"
-cmake -B .build/release -S .
-cmake --build .build/release

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 #include <ncurses.h>
 
+#include <clocale>
 #include <cstdlib>
 #include <ctime>
 
@@ -9,6 +10,9 @@ int main() {
   // Seed the random number generator once at startup so room shapes, door
   // layouts, and enemy positions differ on every run.
   srand(static_cast<unsigned int>(time(nullptr)));
+
+  // Enable locale-aware (UTF-8) input/output for ncursesw.
+  setlocale(LC_ALL, "");
 
   // Initialize ncurses
   initscr();


### PR DESCRIPTION
## Summary

Adding the ``ncursesw`` library for wide character support.

---

## Related Issues

Closes #64 

---

## Changes Made

- Edited the cmake build file to include ``ncurses`` wide support.
- Set the C locale to be via ENV var ``LC_ALL`` <-- need this because base C supports strictly ASCII characters.
- Add ".DS_Store" to git ignores (Mac metadata).

---

## Notes

> [!WARNING]
> Dependent on #70 

Squash merge this mug.